### PR TITLE
fix: fixed publish to run on releaseplease tags

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,8 +1,9 @@
 name: npm publish
 
 on:
-  release:
-    types: [created]
+  push:
+    tags:
+      - 'react-helsinki-notification-manager-v*.*.*'
 
 jobs:
   publish-npm-stable:


### PR DESCRIPTION
As described in the title, publish workflow was not being called because no github release was created.