### PR TITLE
ci: fix release-please inputs for ci-pnpm-node workflow

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -27,8 +27,8 @@ jobs:
     secrets: inherit
     with:
       node-version: '22'
-      upload_artifacts: true
-      skip_sonar: true
+      upload-artifacts: true
+      skip-sonar: true
   publish:
     needs: build
     secrets: inherit


### PR DESCRIPTION
## Summary
- Fixes invalid workflow inputs in `release-please.yml` after the pnpm CI migration (#49)
- Renames `upload_artifacts` → `upload-artifacts` and `skip_sonar` → `skip-sonar` to match `City-of-Helsinki/.github` `ci-pnpm-node.yml` input definitions

## Test plan
- [ ] Merge PR and confirm GitHub no longer reports workflow validation errors on `release-please.yml`
- [ ] On next release, verify the `build` job runs with artifact upload and SonarQube skipped

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release automation settings to use the correct configuration format.
  * Improved reliability of artifact uploads and code-quality checks during releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->